### PR TITLE
wikedzi/change curly brackets to squared brackets on arrays

### DIFF
--- a/src/OAuth/OAuthSignatureMethod.php
+++ b/src/OAuth/OAuthSignatureMethod.php
@@ -56,7 +56,7 @@ abstract class OAuthSignatureMethod {
         // Avoid a timing leak with a (hopefully) time insensitive compare
         $result = 0;
         for ($i = 0; $i < strlen($signature); $i++) {
-            $result |= ord($built{$i}) ^ ord($signature{$i});
+            $result |= ord($built[$i]) ^ ord($signature[$i]);
         }
 
         return $result == 0;


### PR DESCRIPTION
The original code used curly brackets to access array items, that feature is deprecated in PHP 7.4. This update fixes that by replacing the curly bracket with the squared brackets.